### PR TITLE
UITableViewCell customisation

### DIFF
--- a/UI/iOS/CouchUITableSource.h
+++ b/UI/iOS/CouchUITableSource.h
@@ -61,6 +61,10 @@
 @protocol CouchUITableDelegate <UITableViewDelegate>
 @optional
 
+/** Override CouchUITableSource's declaration of tableView:cellForRowAtIndexPath:. */
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath;
+
 /** Called after the query's results change, before the table view is reloaded. */
 - (void)couchTableSource:(CouchUITableSource*)source
      willUpdateFromQuery:(CouchLiveQuery*)query;

--- a/UI/iOS/CouchUITableSource.m
+++ b/UI/iOS/CouchUITableSource.m
@@ -148,21 +148,25 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+  id<UITableViewDelegate> delegate = _tableView.delegate;
+  if ([delegate respondsToSelector: @selector(tableView:cellForRowAtIndexPath:)]) {
+    return [(id<CouchUITableDelegate>)delegate tableView:tableView cellForRowAtIndexPath:indexPath];
+  } else {
     UITableViewCell* cell = [tableView dequeueReusableCellWithIdentifier: @"CouchUITableDelegate"];
-    if (!cell)
-        cell = [[[UITableViewCell alloc] initWithStyle: UITableViewCellStyleDefault
-                                      reuseIdentifier: @"CouchUITableDelegate"]
-                    autorelease];
-    
-    CouchQueryRow* row = [self rowAtIndex: indexPath.row];
-    cell.textLabel.text = [self labelForRow: row];
-    
-    // Allow the delegate to customize the cell:
-    id<UITableViewDelegate> delegate = _tableView.delegate;
-    if ([delegate respondsToSelector: @selector(couchTableSource:willUseCell:forRow:)])
-        [(id<CouchUITableDelegate>)delegate couchTableSource: self willUseCell: cell forRow: row];
+      if (!cell)
+          cell = [[[UITableViewCell alloc] initWithStyle: UITableViewCellStyleDefault
+                                        reuseIdentifier: @"CouchUITableDelegate"]
+                      autorelease];
+      
+      CouchQueryRow* row = [self rowAtIndex: indexPath.row];
+      cell.textLabel.text = [self labelForRow: row];
+      
+      // Allow the delegate to customize the cell:
+      if ([delegate respondsToSelector: @selector(couchTableSource:willUseCell:forRow:)])
+          [(id<CouchUITableDelegate>)delegate couchTableSource: self willUseCell: cell forRow: row];
     
     return cell;
+  }
 }
 
 


### PR DESCRIPTION
Hi,

first off, this is my first Pull Request (at all) so I hope this all makes sense and works out :)

Working with the Grocery List example and trying to extend it with images, I found it a bit hard to customise the UITableViewCell with the given delegate API in the data source class CouchUITableSource. The problem was that the cell is pre-created with UITableViewCellStyleDefault and your options to extend this are limited. For example, in my case if found it difficult to add another image view to the cell's content view.

What I've done is extend the delegate API to allow overriding of tableView:cellForRowAtIndexPath: to set up your own UITableViewCell. I'm not sure if my approach is ideal but it works for me.

Hope that helps,
Sven
