### PR TITLE
Support replication's doc_ids property

### DIFF
--- a/Couch/CouchPersistentReplication.h
+++ b/Couch/CouchPersistentReplication.h
@@ -52,6 +52,9 @@ typedef enum {
     Should be a JSON-compatible dictionary. */
 @property (copy) NSDictionary* query_params;
 
+/** Sets the documents to specify as part of the replication. */
+@property (copy) NSArray *doc_ids;
+
 /** Sets the "user_ctx" property of the replication, which identifies what privileges it will run with when accessing the local server. To replicate design documents, this should be set to a value with "_admin" in the list of roles.
     The server will not let you specify privileges you don't have, so the request to create the replication must be made with credentials that match what you're setting here, unless the server is in no-authentication "admin party" mode.
     See <https://gist.github.com/832610>, section 8, for details.

--- a/Couch/CouchPersistentReplication.m
+++ b/Couch/CouchPersistentReplication.m
@@ -26,7 +26,7 @@
 @implementation CouchPersistentReplication
 
 
-@dynamic source, target, create_target, continuous, filter, query_params;
+@dynamic source, target, create_target, continuous, filter, query_params, doc_ids;
 @synthesize state=_state, completed=_completed, total=_total;
 
 


### PR DESCRIPTION
Added the doc_ids property to CouchPersistentReplication class so that replication can be done using specific document IDs.
