### PR TITLE
Missing argument when raising warning in CouchChangeTracker

### DIFF
--- a/Couch/CouchChangeTracker.m
+++ b/Couch/CouchChangeTracker.m
@@ -194,7 +194,7 @@ enum {
         NSTimeInterval retryDelay = 0.2 * (1 << (_retryCount-1));
         [self performSelector: @selector(start) withObject: nil afterDelay: retryDelay];
     } else {
-        Warn(@"%@: Can't connect, giving up: %@", error);
+        Warn(@"%@: Can't connect, giving up: %@", self, error);
     }
 }
 


### PR DESCRIPTION
Missing argument caused the app to crash when the warning is raised.
