### PR TITLE
document should always choose the highest revision as current revision

### DIFF
--- a/Couch/CouchDocument.m
+++ b/Couch/CouchDocument.m
@@ -270,7 +270,7 @@ NSString* const kCouchDocumentChangeNotification = @"CouchDocumentChange";
     if (!rev)
         return NO;
     
-    if ([_currentRevisionID isEqualToString: rev])
+    if (NSOrderedDescending == [_currentRevisionID compare:rev])
         return NO;
     
     BOOL deleted = [[change objectForKey: @"deleted"] isEqual: (id)kCFBooleanTrue];


### PR DESCRIPTION
Sometime, a document may have a conflict revision with lower revision number but higher sequence number. If db.tracksChanges is set to YES, after the first sync, the document chooses the revision with the higher sequence number as the current revision instead of the higher revision number, which might be wrong.
