### PR TITLE
document should always choose the highest revision as current revision

### DIFF
--- a/Couch/CouchDocument.m
+++ b/Couch/CouchDocument.m
@@ -269,8 +269,7 @@ NSString* const kCouchDocumentChangeNotification = @"CouchDocumentChange";
     NSString* rev = $castIf(NSString, [changeDict objectForKey: @"rev"]);
     if (!rev)
         return NO;
-    
-    if ([_currentRevisionID isEqualToString: rev])
+    if (_currentRevisionID && CouchCompareRevIDs(_currentRevisionID, rev) != NSOrderedAscending)
         return NO;
     
     BOOL deleted = [[change objectForKey: @"deleted"] isEqual: (id)kCFBooleanTrue];

--- a/Couch/CouchRevision.h
+++ b/Couch/CouchRevision.h
@@ -78,3 +78,11 @@
 
 
 @end
+
+/** Compares revision IDs by CouchDB rules: generation number first, then the suffix. */
+NSComparisonResult CouchCompareRevIDs(NSString* revID1, NSString* revID2);
+
+/** SQLite-compatible collation (comparison) function for revision IDs. */
+int CouchCollateRevIDs(void *context,
+                    int len1, const void * chars1,
+                    int len2, const void * chars2);


### PR DESCRIPTION
Sometime, a document may have a conflict revision with lower revision number but higher sequence number. If db.tracksChanges is set to YES, after the first sync, the document chooses the revision with the higher sequence number as the current revision instead of the higher revision number, which might be wrong.

addressing comment from @snej

> This is a great fix, except that the comparison algorithm for revision IDs is a bit more complex. (The numeric prefixes before the "-" need to be compared numerically, otherwise "10-" sorts as lower than "2-".) TouchDB has an implementation of this: the function TDCollateRevIDs() in TDRevision.m. You can just copy that into CouchCocoa for this purpose.
> 
> PS: After making the change please rebase your commits into one instead of adding another commit to the pull request.
